### PR TITLE
Fix private methods on terminal width calculator

### DIFF
--- a/lib/kitcat.rb
+++ b/lib/kitcat.rb
@@ -1,1 +1,2 @@
-Dir["./kitcat/*.rb"].each {|file| require file }
+require 'kitcat/framework'
+require 'kitcat/terminal_width_calculator'

--- a/lib/kitcat/terminal_width_calculator.rb
+++ b/lib/kitcat/terminal_width_calculator.rb
@@ -1,35 +1,37 @@
 module TerminalWidthCalculator
-  def self.calculate
-    default_width = 80
+  class << self
+    def calculate
+      default_width = 80
 
-    term_width = calculate_term_width
+      term_width = calculate_term_width
 
-    term_width > 0 ? term_width : default_width
-  end
-
-  private
-
-  def self.calculate_term_width
-    if ENV['COLUMNS'] =~ /^\d+$/
-      ENV['COLUMNS'].to_i
-    elsif tput_case?
-      `tput cols`.to_i
-    elsif stty_case?
-      `stty size`.scan(/\d+/).map { |s| s.to_i }[1]
+      term_width > 0 ? term_width : default_width
     end
-  rescue
-    0
-  end
 
-  def self.tput_case?
-    (RUBY_PLATFORM =~ /java/ || !STDIN.tty? && ENV['TERM']) && shell_command_exists?('tput')
-  end
+    private
 
-  def self.stty_case?
-    STDIN.tty? && shell_command_exists?('stty')
-  end
+    def calculate_term_width
+      if ENV['COLUMNS'] =~ /^\d+$/
+        ENV['COLUMNS'].to_i
+      elsif tput_case?
+        `tput cols`.to_i
+      elsif stty_case?
+        `stty size`.scan(/\d+/).map { |s| s.to_i }[1]
+      end
+    rescue
+      0
+    end
 
-  def self.shell_command_exists?(command)
-    ENV['PATH'].split(File::PATH_SEPARATOR).any?{|d| File.exists? File.join(d, command) }
+    def tput_case?
+      (RUBY_PLATFORM =~ /java/ || !STDIN.tty? && ENV['TERM']) && shell_command_exists?('tput')
+    end
+
+    def stty_case?
+      STDIN.tty? && shell_command_exists?('stty')
+    end
+
+    def shell_command_exists?(command)
+      ENV['PATH'].split(File::PATH_SEPARATOR).any?{|d| File.exists? File.join(d, command) }
+    end
   end
 end

--- a/lib/kitcat/terminal_width_calculator.rb
+++ b/lib/kitcat/terminal_width_calculator.rb
@@ -1,37 +1,39 @@
-module TerminalWidthCalculator
-  class << self
-    def calculate
-      default_width = 80
+module KitCat
+  module TerminalWidthCalculator
+    class << self
+      def calculate
+        default_width = 80
 
-      term_width = calculate_term_width
+        term_width = calculate_term_width
 
-      term_width > 0 ? term_width : default_width
-    end
-
-    private
-
-    def calculate_term_width
-      if ENV['COLUMNS'] =~ /^\d+$/
-        ENV['COLUMNS'].to_i
-      elsif tput_case?
-        `tput cols`.to_i
-      elsif stty_case?
-        `stty size`.scan(/\d+/).map { |s| s.to_i }[1]
+        term_width > 0 ? term_width : default_width
       end
-    rescue
-      0
-    end
 
-    def tput_case?
-      (RUBY_PLATFORM =~ /java/ || !STDIN.tty? && ENV['TERM']) && shell_command_exists?('tput')
-    end
+      private
 
-    def stty_case?
-      STDIN.tty? && shell_command_exists?('stty')
-    end
+      def calculate_term_width
+        if ENV['COLUMNS'] =~ /^\d+$/
+          ENV['COLUMNS'].to_i
+        elsif tput_case?
+          `tput cols`.to_i
+        elsif stty_case?
+          `stty size`.scan(/\d+/).map { |s| s.to_i }[1]
+        end
+      rescue
+        0
+      end
 
-    def shell_command_exists?(command)
-      ENV['PATH'].split(File::PATH_SEPARATOR).any?{|d| File.exists? File.join(d, command) }
+      def tput_case?
+        (RUBY_PLATFORM =~ /java/ || !STDIN.tty? && ENV['TERM']) && shell_command_exists?('tput')
+      end
+
+      def stty_case?
+        STDIN.tty? && shell_command_exists?('stty')
+      end
+
+      def shell_command_exists?(command)
+        ENV['PATH'].split(File::PATH_SEPARATOR).any?{|d| File.exists? File.join(d, command) }
+      end
     end
   end
 end

--- a/lib/kitcat/terminal_width_calculator.rb
+++ b/lib/kitcat/terminal_width_calculator.rb
@@ -17,7 +17,7 @@ module KitCat
         elsif tput_case?
           `tput cols`.to_i
         elsif stty_case?
-          `stty size`.scan(/\d+/).map { |s| s.to_i }[1]
+          `stty size`.scan(/\d+/).map(&:to_i)[1]
         end
       rescue
         0
@@ -32,7 +32,7 @@ module KitCat
       end
 
       def shell_command_exists?(command)
-        ENV['PATH'].split(File::PATH_SEPARATOR).any?{|d| File.exists? File.join(d, command) }
+        ENV['PATH'].split(File::PATH_SEPARATOR).any? { |d| File.exist? File.join(d, command) }
       end
     end
   end

--- a/spec/kitcat/framework_spec.rb
+++ b/spec/kitcat/framework_spec.rb
@@ -80,10 +80,10 @@ describe KitCat::Framework do
     result.failed_items = failed_items
     result
   end
-  let(:migration_name)             { nil                              }
-  let(:number_of_items_to_process) { nil                              }
-  let(:progress_bar)               { true                             }
+  let(:migration_name)             { nil }
+  let(:number_of_items_to_process) { nil }
   let(:progress_bar_output)        { double('printer').as_null_object }
+  let(:progress_bar)               { nil }
 
   subject do
     described_class.new(strategy, migration_name:             migration_name,
@@ -237,7 +237,7 @@ describe KitCat::Framework do
 
       context 'when the number of items to process is set' do
         let(:number_of_items_to_process) { 5 }
-        let(:last_item_processed) { strategy.items[number_of_items_to_process - 1]}
+        let(:last_item_processed) { strategy.items[number_of_items_to_process - 1] }
 
         context 'and it is less than total number of items' do
           before do
@@ -280,7 +280,6 @@ describe KitCat::Framework do
 
   describe '#progress_bar?' do
     context 'when framework instantiated without progress bar option' do
-      let(:progress_bar) { nil }
       it 'returns true that progress bar is enabled' do
         expect(subject.progress_bar?).to eq(true)
       end
@@ -295,7 +294,7 @@ describe KitCat::Framework do
     end
 
     context 'when framework instantiated with progress bar option on' do
-      let(:progress_bar) { true }
+      let(:progress_bar)  { true }
 
       it 'returns true that progress bar is enabled' do
         expect(subject.progress_bar?).to eq(true)
@@ -396,7 +395,7 @@ describe KitCat::Framework do
             end
 
             # note that last line is for the end of processing
-            expect(log_lines[-2]).to include("error while processing item: #{KitCat::Test::Strategy::Item.new(strategy.items.select {|i| failed_items.include?(i)}.first).to_log}")
+            expect(log_lines[-2]).to include("error while processing item: #{KitCat::Test::Strategy::Item.new(strategy.items.select { |i| failed_items.include?(i)}.first).to_log }")
           end
         end
       end
@@ -417,7 +416,7 @@ describe KitCat::Framework do
         end
 
         context 'when there is an item that cannot be processed' do
-          let(:failed_items) { [ (1..minimum_number_of_items).to_a.sample ] }
+          let(:failed_items) { [(1..minimum_number_of_items).to_a.sample] }
 
           it 'increments progress bar only for the processed items' do
             expect do


### PR DESCRIPTION
This PR refactors `terminal_width_calculator.rb` so the methods that were intended to be private are actually private.

@chmeldax 
