### PR TITLE
Handle StandardError exceptions raised by the strategy#process.

### DIFF
--- a/lib/kitcat/framework.rb
+++ b/lib/kitcat/framework.rb
@@ -49,27 +49,34 @@ module KitCat
       @number_of_items_processed = 0
 
       items.each do |item|
-        if migration_strategy.process(item)
+        begin
+          if migration_strategy.process(item)
 
-          log_success(item)
+            log_success(item)
 
-          @number_of_items_processed += 1
+            @number_of_items_processed += 1
 
-          increment_progress_bar
+            increment_progress_bar
 
-          @last_item_processed = item
+            @last_item_processed = item
 
-          break unless process_more?
-        else
+            break unless process_more?
+          else
+            log_failure(item)
+
+            break
+          end
+          if @interrupted
+            handle_user_interrupt
+            break
+          end
+        rescue StandardError
           log_failure(item)
-
-          break
-        end
-        if @interrupted
-          handle_user_interrupt
-          break
+          raise
         end
       end
+
+    ensure
       end_logging
     end
 


### PR DESCRIPTION
We realized that a strategy#process might raise a StandardError exception that
wouldn't allow the framework to log the failed item. So, we added the rescue
for that exception, log the failed item and then raise the exception.
This is very helpful, because, now we have the failed item in the log.

@ljones140 @chmeldax @erishine 
