### PR TITLE
Deploying/Releasing process made simpler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,26 @@ sudo: false
 cache: bundler
 language: ruby
 rvm:
-  - 2.2
-  - 2.3.0
-  - ruby-head
-  - jruby-9.0.5.0
+- 2.2
+- 2.3.0
+- ruby-head
+- jruby-9.0.5.0
 env:
-  # this doesn't do anything for MRI or RBX, but it doesn't hurt them either
-  # for JRuby, it enables us to get more accurate coverage data
-  - JRUBY_OPTS="--debug"
+- JRUBY_OPTS="--debug"
 matrix:
   allow_failures:
-    - rvm: ruby-head
+  - rvm: ruby-head
   fast_finish: true
 before_install: gem update --remote bundler
 install:
-  - bundle install --retry=3
+- bundle install --retry=3
 script:
-  - bundle exec rake
+- bundle exec rake
+deploy:
+  provider: rubygems
+  api_key:
+    secure: rsAAPd+SK72E8V5kphNomXGuE7VET/fP51P7JX+TzFfiZEQn7jQiqCEOtRcAiJYIroAZR834Z0BT0DGIYp92Dfh5LvLaaYSN2KJwZU6VhAaRvU7czGFT+4ScJuqqZS1sBn1L2YNgM/dTQ2BNq1mJE22ezwcBzFuenMuLAQf6obNV3FEdn/Z2WLe0FsBvsb6B/PHrvCeZo3NSmYuiwMBbdUEdL3W2ffrxacr6ErWNfPro7DuxKwJXPiDXrLam5tv6rmkASHgp34546LkZrWH5ny8G5qBJHXQh6yCGxu9XNXp3AMQ/i8H9w0E5WDXFo9l+gTAiWBEOp4zR3Arxjz3msp9tjmhAgyITZNpeiSgd4ltKTIOFinFg+R2H2HG7j4vDGfdUqBuHp30UUeWMPybJ62YcPqvF5nBzGG26U9Gv7RTysnZPRFM1hZH+F7Dj5HNBFK7bF64vb8d5AmYzWIxkkncjDciZmNfZo7bBaa6HJ/H8UpiCvAboyNptsp8WkN9vnZAcfY2h+yrWYRkFK4HF9vlGKibwWYVT3AUgLwr3+LdrXJxIFponqf6lqKVNLOXfJ9TM3S8Bs7P/cYSabXlDTaNA/x+qoLmadL/y6fqKKQ7+ZzTdXgHkuDldglaXRH8Dkv6XHo/On2/kGJBAnnFT2G9GAo0nNovfLU3RuGfCeIg=
+  gem: kitcat
+  on:
+    tags: true
+    repo: simplybusiness/kitcat

--- a/kitcat.gemspec
+++ b/kitcat.gemspec
@@ -1,6 +1,11 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'kitcat/version'
+
 Gem::Specification.new do |gem|
   gem.name          = 'kitcat'
-  gem.version       = '1.0.2'
+  gem.version       = Kitcat::VERSION
   gem.summary       = 'a framework to support data processing'
   gem.description   = 'initially created for data migrations. Provides logging, progess bar and graceful handling'
   gem.licenses      = ['MIT']

--- a/lib/kitcat.rb
+++ b/lib/kitcat.rb
@@ -1,5 +1,6 @@
 require 'kitcat/framework'
 require 'kitcat/terminal_width_calculator'
+require 'kitcat/version'
 
 # Backward compatibility
 KitCat = Kitcat

--- a/lib/kitcat/version.rb
+++ b/lib/kitcat/version.rb
@@ -1,0 +1,3 @@
+module Kitcat
+  VERSION = '1.0.2'
+end

--- a/lib/kitcat/version.rb
+++ b/lib/kitcat/version.rb
@@ -1,3 +1,3 @@
 module Kitcat
-  VERSION = '1.0.2'
+  VERSION = '1.0.2'.freeze
 end


### PR DESCRIPTION
- Travis will automatically push gem to RubyGems
- Version.rb introduced
- We can use `gem-release` (as a global gem) to do the bumps of versions.

Please review @simplybusiness/migration-tech-charter 

See issue: https://github.com/simplybusiness/kitcat/issues/19
